### PR TITLE
Change order so examples are at the top

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -9,7 +9,7 @@ function SEO({ title, pkg }) {
       meta={[
         {
           name: 'description',
-          content: `Learn how to use ${pkg} by viewing and forking ${pkg} examples apps on
+          content: `Learn how to use ${pkg} by viewing and forking ${pkg} example apps on
         CodeSandbox`
         },
         {
@@ -18,7 +18,7 @@ function SEO({ title, pkg }) {
         },
         {
           property: 'og:description',
-          content: `Learn how to use ${pkg} by viewing and forking ${pkg} examples apps on
+          content: `Learn how to use ${pkg} by viewing and forking ${pkg} example apps on
         CodeSandbox`
         },
         {
@@ -39,7 +39,7 @@ function SEO({ title, pkg }) {
         },
         {
           name: 'twitter:description',
-          content: `Learn how to use ${pkg} by viewing and forking ${pkg} examples apps on
+          content: `Learn how to use ${pkg} by viewing and forking ${pkg} example apps on
         CodeSandbox`
         }
       ]}

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -10,7 +10,7 @@ const Wrapper = styled(Element)`
   border: 1px solid ${designLanguage.colors.grays[600]};
 
   @media screen and (max-width: 1000px) {
-    order: -1;
+    order: 1;
     width: 100%;
   }
 `


### PR DESCRIPTION
Examples are the key thing, metadata is supplementary so it makes sense for the results to be listed above the metadata when it has to.